### PR TITLE
Enable CPU fallback for OpenCL

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Work for Ethereum
 
 ## Features
 
-- Multi-threaded CPU search with optional GPU acceleration for SHA256 and RIPEMD160 using OpenCL. Enable with `-sh N` where `N` is the number of shaders.
+- Multi-threaded CPU search with optional GPU acceleration for SHA256 and RIPEMD160 using OpenCL. Enable with `-sh N` where `N` is the number of shaders. If no GPU is found the engine will attempt to use a CPU-based OpenCL device instead.
 - Skip arbitrary key ranges by specifying a file with `-g ranges.txt`.
 - Distributed coordinator/worker mode (`-x` to host, `-y` to connect) to share work between nodes.
 - Automatic checkpoint/resume of the last scanned key every 5 seconds.

--- a/ocl_engine.cpp
+++ b/ocl_engine.cpp
@@ -41,8 +41,12 @@ int ocl_init(int requested) {
     }
     err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, 1, &device, &num);
     if(err != CL_SUCCESS) {
-        fprintf(stderr, "[E] No OpenCL GPU device found\n");
-        return 0;
+        fprintf(stderr, "[W] No OpenCL GPU device found, trying CPU\n");
+        err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_CPU, 1, &device, &num);
+        if(err != CL_SUCCESS) {
+            fprintf(stderr, "[E] No suitable OpenCL device found\n");
+            return 0;
+        }
     }
     cl_uint cu;
     clGetDeviceInfo(device, CL_DEVICE_MAX_COMPUTE_UNITS, sizeof(cu), &cu, NULL);


### PR DESCRIPTION
## Summary
- support CPU OpenCL devices when no GPU is detected
- mention CPU fallback in README

## Testing
- `make -j4`
- `./keyhunt -m rmd160-bsgs -f tests/1to32.rmd -r 1:1F -l compress -s 5 -R -k 20 -sh 10 -q`

------
https://chatgpt.com/codex/tasks/task_e_686bef54fc148322ac244ffb0275ae5f