### PR TITLE
Fix loading checkpoint newline issue

### DIFF
--- a/keyhunt.cpp
+++ b/keyhunt.cpp
@@ -409,6 +409,7 @@ static bool load_checkpoint(Int &val) {
         return false;
     }
     fclose(f);
+    trim(buf, " \t\n\r");
     val.SetBase16(buf);
     return true;
 }


### PR DESCRIPTION
## Summary
- trim trailing whitespace before parsing the checkpoint file

## Testing
- `make` (with OpenCL enabled)

------
https://chatgpt.com/codex/tasks/task_e_686c260e8fe88322ad647dd6f936c613