### PR TITLE
Fix whitespace parsing for SetBaseN

### DIFF
--- a/secp256k1/Int.cpp
+++ b/secp256k1/Int.cpp
@@ -999,9 +999,13 @@ void  Int::SetBaseN(int n,const char *charset,const char *value) {
   Int c;
   int lgth = (int)strlen(value);
   for(int i=lgth-1;i>=0;i--) {
-    char *p = strchr((char*)charset,toupper(value[i]));
+    int ch = (unsigned char)value[i];
+    if(isspace(ch) || ch=='\r')
+      continue;
+    ch = toupper(ch);
+    char *p = strchr((char*)charset,ch);
     if(!p) {
-		printf("Invalid charset !!\n");
+      printf("Invalid charset !!\n");
       return;
     }
     int id = (int)(p-charset);

--- a/secp256k1/Int.cpp
+++ b/secp256k1/Int.cpp
@@ -925,7 +925,14 @@ void Int::SetBase10(const char *value) {
   Int c;
   int lgth = (int)strlen(value);
   for(int i=lgth-1;i>=0;i--) {
-    uint32_t id = (uint32_t)(value[i]-'0');
+    int ch = (unsigned char)value[i];
+    if(isspace(ch) || ch=='\r')
+      continue;
+    if(ch < '0' || ch > '9') {
+      printf("Invalid digit in decimal string!\n");
+      return;
+    }
+    uint32_t id = (uint32_t)(ch - '0');
     c.Set(&pw);
     c.Mult(id);
     Add(&c);


### PR DESCRIPTION
## Summary
- normalize whitespace when reading numbers with `Int::SetBaseN`

## Testing
- `make OPENCL=0`
- `./keyhunt -m rmd160 -f tests/71.rmd -r 7a0000000000000000:7fffffffffffffffff -l compress -s 10 -R -S`


------
https://chatgpt.com/codex/tasks/task_e_686c32088f6483229735befa09e7dece